### PR TITLE
Fix NullPointerException in PlayFabHTTP

### DIFF
--- a/targets/java/source_shared/src/main/java/com/playfab/internal/PlayFabHTTP.java
+++ b/targets/java/source_shared/src/main/java/com/playfab/internal/PlayFabHTTP.java
@@ -76,7 +76,7 @@ public class PlayFabHTTP {
             try {
                 errorResult = gson.fromJson(responseString, PlayFabJsonError.class);
             } catch(Exception e) {
-                return GeneratePfError(httpCode, PlayFabErrorCode.JsonParseError, "Server response not proper json :" + responseString, errorResult.retryAfterSeconds, null);
+                return GeneratePfError(httpCode, PlayFabErrorCode.JsonParseError, "Server response not proper json :" + responseString, null, null);
             }
 
             httpCode = errorResult.code;


### PR DESCRIPTION
errorResult was not initialized when an exception is thrown when serializing PlayFabJsonError on line 77.